### PR TITLE
Mdl 63677 35 policy redirection

### DIFF
--- a/admin/tool/policy/classes/api.php
+++ b/admin/tool/policy/classes/api.php
@@ -981,6 +981,8 @@ class api {
         $cache = \cache::make('core', 'presignup');
         $cache->delete('tool_policy_userpolicyagreed');
         $cache->delete('tool_policy_viewedpolicies');
+        $cache->delete('tool_policy_issignup');
+        $cache->delete('isminor');
 
         // Get all active policies.
         $currentpolicyversions = static::get_current_versions_ids(policy_version::AUDIENCE_LOGGEDIN);

--- a/lib/db/caches.php
+++ b/lib/db/caches.php
@@ -383,8 +383,5 @@ $definitions = array(
         'simplekeys' => true,
         'simpledata' => true,
         'ttl' => 1800,
-        'invalidationevents' => array(
-            'createduser',
-        )
     ),
 );


### PR DESCRIPTION
This PR fixes an issue we found with the account creation process. We were finding that when multiple people were attempting to create an account with the new tool_policy plugin enabled, they would be bounced back in the process at random. It turns out the presignup cache is being being cleared on the 'createduser' event - any user. This removes the policy viewed/accepted states for EVERY session, causing users to be bounced back to the homepage or initial policy page and often being unable to create a new account.
